### PR TITLE
Fix for blink-blink

### DIFF
--- a/exercises/blink_blink/exercise.js
+++ b/exercises/blink_blink/exercise.js
@@ -23,10 +23,6 @@ exercise.addProcessor(function (mode, callback) {
   }, 4000)
 })
 
-var pins = {
-  led: 13
-}
-
 // add a processor only for 'verify' calls
 exercise.addVerifyProcessor(verifyProcessor(exercise, function (test, done) {
   var io = five.stubs.firmata.singleton
@@ -36,21 +32,14 @@ exercise.addVerifyProcessor(verifyProcessor(exercise, function (test, done) {
   var led = five.Led.instances[0]
 
   test.truthy(led, 'create_led_instance')
-  test.equals(led.pin, pins.led, 'connect_led_to_pin', {pin: pins.pins})
-  test.truthy(led.strobe.called || led.blink.called, 'led_flashing')
+  test.truthy(led.pin, 'connect_led_to_pin', { pin: led.pin })
+  test.truthy(led.strobe.called || led.blink.called, 'blink_strobe_called')
 
   if (led.blink.called) {
     test.equals(led.blink.getCall(0).args[0], 1000, 'led_flashing')
   } else {
     test.equals(led.strobe.getCall(0).args[0], 1000, 'led_flashing')
   }
-
-  // should have set pin 13 into digital output mode
-  test.truthy(io.pinMode.calledWith(13, io.MODES.OUTPUT), 'pin_mode', {pin: 2, mode: 'OUTPUT'})
-
-  // should have turned pin 13 on and off
-  test.truthy(io.digitalWrite.calledWith(13, io.HIGH), 'pin_turned_on')
-  test.truthy(io.digitalWrite.calledWith(13, io.LOW), 'pin_turned_off')
 
   done()
 }))

--- a/exercises/blink_blink/solution/solution.js
+++ b/exercises/blink_blink/solution/solution.js
@@ -2,6 +2,6 @@ var five = require('johnny-five')
 var board = new five.Board()
 
 board.on('ready', function () {
-  var led = new five.Led(13)
-  led.strobe(1000)
+  var led = new five.Led(5, { mode: 2 })
+  led.blink(1000)
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -60,15 +60,12 @@
   "exercises": {
     "blink_blink": {
       "pass": {
-        "led_flashing": "LED is flashing once a second",
-        "pin_turned_on": "Pin 13 was turned on",
-        "pin_turned_off": "Pin 13 was turned off"
+        "blink_strobe_called": "blink() or strobe() was called",
+        "led_flashing": "LED is flashing once a second"
       },
       "fail": {
-        "led_flashing": "LED is not flashing once a second",
-        "pin_mode": "Pin 13 was not set to OUTPUT mode",
-        "pin_turned_on": "Pin 13 was never turned on",
-        "pin_turned_off": "Pin 13 was never turned off"
+        "blink_strobe_called": "blink() or strobe() was not called",
+        "led_flashing": "LED is not flashing once a second"
       }
     },
     "fire_alarm": {

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -61,14 +61,11 @@
     "blink_blink":{
       "pass":{
         "led_flashing":"La LED flashe une fois par seconde",
-        "pin_turned_on":"La broche 13 a basculé en état haut",
-        "pin_turned_off":"La broche 13 a basculé en état haut"
+        "blink_strobe_called": "blink() ou strobe() a été appelé"
       },
       "fail":{
         "led_flashing":"La LED ne clignote pas une fois par seconde",
-        "pin_mode":"Broche 13 n’a pas été configurée en mode OUTPUT",
-        "pin_turned_on":"La broche 13 n'a jamais basculé en état haut",
-        "pin_turned_off":"La broche 13 n'a jamais basculé en état bas"
+        "blink_strobe_called": "blink() ou strobe() n'a pas été appelé"
       }
     },
     "fire_alarm":{

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -61,14 +61,9 @@
     "blink_blink": {
       "pass": {
         "led_flashing": "LED is flashing once a second",
-        "pin_turned_on": "Pin 13 was turned on",
-        "pin_turned_off": "Pin 13 was turned off"
       },
       "fail": {
         "led_flashing": "LED is not flashing once a second",
-        "pin_mode": "Pin 13 was not set to OUTPUT mode",
-        "pin_turned_on": "Pin 13 was never turned on",
-        "pin_turned_off": "Pin 13 was never turned off"
       }
     },
     "fire_alarm": {


### PR DESCRIPTION
Closes #31

This commit makes it more generic.
Some tests were removed, because they test the behaviour of johnny five as opposed to the solution code itself.
Localizations for those were cleaned up as well.

Some constants in code and localizations were replaced with actual variables.

Courtesy of [NodeSchool Vancouver](https://nodeschool.io/vancouver) :)
