### PR TITLE
Resolve: Issue #41 - Ping Bell: "Piezo didn't play a tone when sent a UDP message" 

### DIFF
--- a/exercises/ping_bell/exercise.js
+++ b/exercises/ping_bell/exercise.js
@@ -40,7 +40,7 @@ exercise.addVerifyProcessor(verifyProcessor(exercise, function (test, done) {
   test.equals(piezo.pin, pins.piezo, 'connect_speaker_to_pin', {pin: pins.piezo})
 
   var initial = {
-    tone: {callCount: piezo.tone.callCount}
+    play: {callCount: piezo.play.callCount}
   }
 
   var buffer = new Buffer('HAI!?')
@@ -50,7 +50,7 @@ exercise.addVerifyProcessor(verifyProcessor(exercise, function (test, done) {
   // Allow some time for the udp packet to reach server and sound to be played
   setTimeout(function () {
     try {
-      test.truthy(piezo.tone.callCount > initial.tone.callCount, 'speaker_played_tune_on_udp_message')
+      test.truthy(piezo.play.callCount > initial.play.callCount, 'speaker_played_tune_on_udp_message')
 
       done()
     } catch (error) {


### PR DESCRIPTION
## How issue is resolved?
Piezo has changed the name of the "tone" method to "play". For this, the method is changed in the test cases of the file corresponding to ping_bell.

---
## How to test

**To pass test.**
- Add the current and correct implementation of e.g: 
 ```
piezo.play({
    // song is composed by a string of notes
    // a default beat is set, and the default octave is used
    // any invalid note is read as "no note"
    song: "C D F D A - A A A A G G G G - - C D F D G - G G G G F F F F - -",
    beats: 1 / 4,
    tempo: 100
  });
```
on `server.on` function.

**To fail test.**
- Standard way to fail this test case. E.g: forget to put Piezo.

---
## Additional
The file involved file is exercise.js located in nodebot-workshop/exercises/ping_bell/
 