### PR TITLE
update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 
 node_js:
-  - '5'
-  - '7'
   - 'lts/*'
   - 'node'
 

--- a/exercises/remote_temperature/exercise.js
+++ b/exercises/remote_temperature/exercise.js
@@ -48,7 +48,8 @@ exercise.addVerifyProcessor(verifyProcessor(exercise, function (test, done) {
     return random(133, 163) // Between ~ 15 deg and 30 deg
   })
 
-  var d = dnode.connect(1337)
+  var d = dnode(() => {}, { weak: false })
+  d = d.connect(1337)
 
   d.on('remote', function (remote) {
     try {

--- a/exercises/remote_temperature/solution/solution.js
+++ b/exercises/remote_temperature/solution/solution.js
@@ -14,11 +14,14 @@ board.on('ready', function () {
     temp = this.celsius
   })
 
-  var server = dnode({
-    getTemperature: function (cb) {
-      cb(temp)
-    }
-  })
+  var server = dnode(
+    {
+      getTemperature: function (cb) {
+        cb(temp)
+      }
+    },
+    { weak: false }
+  )
 
   server.listen(1337)
 })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,4 @@ gulp.task('verify-solutions', function() {
     })
 })
 
-gulp.task('default', ['lint', 'verify-solutions'], function() {
-  // place code for your default task here
-})
+gulp.task('default', gulp.parallel('lint', 'verify-solutions'))

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "url": "https://github.com/tableflip/nodebot-workshop/issues"
   },
   "dependencies": {
-    "async": "^2.6.0",
+    "async": "^3.1.0",
     "dnode": "^1.2.2",
     "ioboard": "^3.0.0",
-    "johnny-five": "^0.14.1",
+    "johnny-five": "^1.3.0",
     "proxyquire": "^2.0.0",
     "sinon": "^4.4.2",
     "workshopper-adventure": "^6.0.3",
@@ -50,9 +50,9 @@
     "node-notifier": "^5.2.1"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-jshint": "^2.1.0",
-    "gulp-shell": "^0.6.5",
+    "gulp-shell": "^0.7.1",
     "jshint": "^2.9.5",
     "jshint-stylish": "^2.2.1",
     "pre-commit": "^1.2.2"


### PR DESCRIPTION
Update `gulp`, `johnny-five` and `async` dependencies.

Aside I found some problems to install `weak` in node v12, and since `dnode` allow to [use optionally](https://github.com/substack/dnode/blob/master/index.js#L26).

Still missing update `sinon` to get all dependencies up to date. I think could be in another PR.