### PR TITLE
chore: update SerialPort stub

### DIFF
--- a/stubs/serialport-stub.js
+++ b/stubs/serialport-stub.js
@@ -5,9 +5,9 @@ var SerialPort = function() {
 }
 
 SerialPort.list = sinon.stub()
-SerialPort.list.callsArgWithAsync(0, null, [{
+SerialPort.list.resolves([{
   // has to match the regex /usb|acm|^com/i
-  comName: '/dev/cu.usbserial-FAKEID'
+  path: '/dev/cu.usbserial-FAKEID'
 }])
 
 module.exports = sinon.spy(SerialPort)


### PR DESCRIPTION
with last `johnny-five` release, SerialPort was updated. This PR update the stub to match that changes.

https://github.com/rwaldron/johnny-five/releases
https://github.com/rwaldron/johnny-five/commit/83f8ea703f4399a4f220b04d9dcdd8afa22820c3